### PR TITLE
Feature/all 35

### DIFF
--- a/Python3/Users/Get_Org_Unit_User_Roles.py
+++ b/Python3/Users/Get_Org_Unit_User_Roles.py
@@ -19,19 +19,8 @@ def get_org_unit_users(org_unit_id, base_uri, access_token, page_number=1, page_
 
     OUTPUTS
     Returns a JSON object containing the list of users and pagination information.
-
-    NOTES
-    - This endpoint is currently in a preview stage.
-    - The function uses the requests library for making HTTP requests.
-    - Error handling is implemented for common HTTP errors.
-
-    USAGE_EXAMPLE
-    users = get_org_unit_users("12345", "https://api.example.com", "your_access_token")
-    print(users)
-
-    PROMPT
-    Read the OpenAPI Spec and using the details and parameters for the GET /api/org-units/{orgUnitId}/users endpoint, write a helper function that would accept those parameters as arguments and returns the output as a JSON object.
     """
+
     import requests
     import logging
 
@@ -61,18 +50,15 @@ def get_org_unit_users(org_unit_id, base_uri, access_token, page_number=1, page_
     if sort_order:
         params["sortOrder"] = sort_order
 
-    # Use the New-HttpQueryString function (assumed to be available)
-    query_string = New-HttpQueryString(Parameters=params)
-
     # Log the request details
     logger.debug(f"Making GET request to: {url}")
     logger.debug(f"Headers: {headers}")
-    logger.debug(f"Query parameters: {query_string}")
+    logger.debug(f"Query parameters: {params}")
 
     try:
-        # Make the GET request
-        response = requests.get(url, headers=headers, params=query_string)
-        
+        # Make the GET request with the constructed URL, headers, and parameters
+        response = requests.get(url, headers=headers, params=params)
+
         # Check for successful response
         response.raise_for_status()
 

--- a/Python3/Users/Get_Org_Unit_User_Roles.py
+++ b/Python3/Users/Get_Org_Unit_User_Roles.py
@@ -1,6 +1,6 @@
 def get_org_unit_users(org_unit_id, base_uri, access_token, page_number=1, page_size=50, select=None, sort_by=None, sort_order="ASC"):
     """
-    SYNOPSIS
+     SYNOPSIS
     Retrieve the list of users for a specific organization unit.
 
     DESCRIPTION
@@ -19,6 +19,18 @@ def get_org_unit_users(org_unit_id, base_uri, access_token, page_number=1, page_
 
     OUTPUTS
     Returns a JSON object containing the list of users and pagination information.
+
+    NOTES
+    - This endpoint is currently in a preview stage.
+    - The function uses the requests library for making HTTP requests.
+    - Error handling is implemented for common HTTP errors.
+
+    USAGE_EXAMPLE
+    users = get_org_unit_users("12345", "https://api.example.com", "your_access_token")
+    print(users)
+
+    PROMPT
+    Read the OpenAPI Spec and using the details and parameters for the GET /api/org-units/{orgUnitId}/users endpoint, write a helper function that would accept those parameters as arguments and returns the output as a JSON object
     """
 
     import requests


### PR DESCRIPTION
Changes Made:
Removed the New-HttpQueryString call and instead passed the params dictionary directly to the requests.get() call.
The requests library automatically handles encoding the query parameters, so there's no need for a separate query string building function.
This version should resolve the error "HttpQueryString" is not defined and allow us to properly pass query parameters using the requests library.